### PR TITLE
Allowing parents of brakets to be used around PR numbers

### DIFF
--- a/changebot/changelog.py
+++ b/changebot/changelog.py
@@ -3,7 +3,7 @@ import re
 __all__ = ['check_changelog_consistency']
 
 
-BLOCK_PATTERN = re.compile('\[#.+\]', flags=re.DOTALL)
+BLOCK_PATTERN = re.compile('[[(]#[0-9#, ]+[])]')
 ISSUE_PATTERN = re.compile('#[0-9]+')
 
 


### PR DESCRIPTION
To have the same effect as the release scripts, e.g. astroquery is not very strict about the format and accepts both ``()`` or ``[]`` around the PR numbers in the changelog