### PR TITLE
Don't report on changelog for WIP PRs

### DIFF
--- a/changebot/webapp.py
+++ b/changebot/webapp.py
@@ -97,6 +97,9 @@ def hook():
             message = (message.replace('issues with', 'issue with')
                        .replace('fix these', 'fix this'))
 
+    elif 'Work in progress' in pr_handler.labels:
+        message += ("I see this is a work in progress pull request. I'll "
+                    "carry out the checks once the PR is ready for review.")
     else:
 
         message += "Everything looks good from my point of view! :+1:"


### PR DESCRIPTION
Inspired by comment here: https://github.com/astropy/astropy/pull/5598#issuecomment-319457080

While the bot complain about issues with the PR, I think it still makes sense to set the status fail to prevent merge if there are any inconsistencies.