### PR TITLE
get_issues() to only return issues, not PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+.cache
+*~

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -99,7 +99,7 @@ class RepoHandler(object):
         contents_base64 = response.json()['content']
         return base64.b64decode(contents_base64).decode()
 
-    def get_issues(self, state, labels):
+    def get_issues(self, state, labels, exclude_pr=True):
         """
         Get a list of issues.
 
@@ -111,12 +111,25 @@ class RepoHandler(object):
         labels : str
            List of comma-separated labels; e.g., ``Closed?``.
 
+        exclude_pr : bool
+            Exclude pull requests from result.
+
+        Returns
+        -------
+        issue_list : list
+            A list of matching issue numbers.
+
         """
         url = f'{HOST}/repos/{self.repo}/issues'
         kwargs = {'state': state, 'labels': labels}
         r = requests.get(url, kwargs)
         result = r.json()
-        return [d['number'] for d in result]
+        if exclude_pr:
+            issue_list = [d['number'] for d in result
+                          if 'pull_request' not in d]
+        else:
+            issue_list = [d['number'] for d in result]
+        return issue_list
 
 
 class IssueHandler(object):

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -209,19 +209,7 @@ class IssueHandler(object):
         """
 
         data = {}
-        data['body'] = body
-
-        # Troll mode on special day for new pull request
-        tt = time.gmtime()  # UTC because we're astronomers!
-        if tt.tm_mon == 4 and tt.tm_mday == 1:
-            import random
-
-            try:
-                q = random.choice(QUOTES)
-            except Exception as e:
-                q = str(e)  # Need a way to find out what went wrong
-
-            data['body'] += f'\n*{q}*\n'
+        data['body'] = _insert_special_message(body)
 
         if comment_id is None:
             url = self._url_issue_comment
@@ -359,3 +347,19 @@ class PullRequestHandler(IssueHandler):
         if last_time == 0:
             raise Exception(f'No commit found in {url}')
         return last_time
+
+
+def _insert_special_message(body):
+    """Troll mode on special day for new pull request."""
+    tt = time.gmtime()  # UTC because we're astronomers!
+    if tt.tm_mon != 4 or tt.tm_mday != 1:
+        return body
+
+    import random
+
+    try:
+        q = random.choice(QUOTES)
+    except Exception as e:
+        q = str(e)  # Need a way to find out what went wrong
+
+    return body + f'\n*{q}*\n'

--- a/changebot/github/tests/test_github_api.py
+++ b/changebot/github/tests/test_github_api.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch, Mock
 
+from changebot.github import github_api
 from changebot.github.github_api import RepoHandler
 
 
-# TODO: Add tests for other methods.
+# TODO: Add more tests to increase coverage.
+
 class TestRepoHandler:
     def setup_class(self):
         self.repo = RepoHandler('fakerepo/doesnotexist', branch='awesomebot')
@@ -21,3 +23,17 @@ class TestRepoHandler:
         assert self.repo.get_issues('open', 'Close?') == [42]
         assert self.repo.get_issues('open', 'Close?',
                                     exclude_pr=False) == [42, 55]
+
+
+@patch('time.gmtime')
+def test_special_msg(mock_time):
+    import random
+    random.seed(1234)
+    body = 'Hello World\n'
+
+    mock_time.return_value = Mock(tm_mon=4, tm_mday=2)
+    assert github_api._insert_special_message(body) == body
+
+    mock_time.return_value = Mock(tm_mon=4, tm_mday=1)
+    body2 = github_api._insert_special_message(body)
+    assert '\n*Greetings from Skynet!*\n' in body2

--- a/changebot/github/tests/test_github_api.py
+++ b/changebot/github/tests/test_github_api.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch, Mock
+
+from changebot.github.github_api import RepoHandler
+
+
+# TODO: Add tests for other methods.
+class TestRepoHandler:
+    def setup_class(self):
+        self.repo = RepoHandler('fakerepo/doesnotexist', branch='awesomebot')
+
+    @patch('requests.get')
+    def test_get_issues(self, mock_get):
+        # http://engineroom.trackmaven.com/blog/real-life-mocking/
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {'number': 42, 'state': 'open'},
+            {'number': 55, 'state': 'open',
+             'pull_request': {'diff_url': 'blah'}}]
+        mock_get.return_value = mock_response
+
+        assert self.repo.get_issues('open', 'Close?') == [42]
+        assert self.repo.get_issues('open', 'Close?',
+                                    exclude_pr=False) == [42, 55]


### PR DESCRIPTION
Fix #34 by limiting `get_issues()` to really only get issues, not PRs. Since PR handler has its own methods to get open PRs, this should not break anything?
```python
>>> changebot.github.github_api import RepoHandler
>>> repo = RepoHandler('astropy/astropy')
>>> repo.get_issues('open', 'Close?')  # No 3845
[6025, 5193, 4842, 4549, 3951, 2603, 2232, 435, 383, 282]
>>> repo.get_issues('open', 'Close?', exclude_pr=False)  # Has 3845
[6025, 5193, 4842, 4549, 3951, 3845, 2603, 2232, 1920, 435, 383, 282]
```

Also added a test for this as per #33.

p.s. I briefly thought about having `get_issues()` to return a list of handlers instead of just numbers, but that has larger overhead, so will need a good reason to do so.