### PR TITLE
Gracefully handle missing changelog

### DIFF
--- a/changebot/blueprints/changelog_helpers.py
+++ b/changebot/blueprints/changelog_helpers.py
@@ -59,7 +59,7 @@ def check_changelog_consistency(repo_handler, pr_handler):
         else:
             break
     else:
-        raise FileNotFoundError("CHANGES.rst")
+        return ["This repository does not appear to have a change log!"]
 
     return review_changelog(pr_handler.number, changelog,
                             pr_handler.milestone, pr_handler.labels)

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -101,6 +101,8 @@ class RepoHandler(object):
         url_file = self._url_contents + path_to_file
         data = {'ref': self.branch}
         response = requests.get(url_file, params=data, headers=self._headers)
+        if not response.ok and response.json()['message'] == 'Not Found':
+            raise FileNotFoundError(path_to_file)
         assert response.ok, response.content
         contents_base64 = response.json()['content']
         return base64.b64decode(contents_base64).decode()


### PR DESCRIPTION
I think this is a combination of a bug fix and a slight improvement. Previously, if a change log was missing in the repo, the bot would fail silently. Now it should provide a helpful message.

Also, I don't think the loop that looked for change logs with different names was working properly prior to this update.