### PR TITLE
Avoid timeout when checking for stale issues/pull requests

### DIFF
--- a/changebot/blueprints/stale_issues.py
+++ b/changebot/blueprints/stale_issues.py
@@ -15,8 +15,13 @@ def close_stale_issues():
             return f'Payload mising {keyword}'
     if payload['cron_token'] != current_app.cron_token:
         return "Incorrect cron_token"
-    process_issues(payload['repository'], payload['installation'])
-    return "All good"
+    # process_issues is a generator so that we can continuously return a
+    # response to the requester - this prevents Heroku from thinking the
+    # request has timed out (https://librenepal.com/article/flask-and-heroku-timeout/)
+    for status in process_issues(payload['repository'], payload['installation']):
+        print(status)
+        yield status
+    return "Finished checking for stale issues"
 
 
 ISSUE_CLOSE_WARNING = """
@@ -55,7 +60,7 @@ def process_issues(repository, installation):
 
     for n in issuelist:
 
-        print(f'Checking {n}')
+        yield f'Checking {n}'
 
         issue = IssueHandler(repository, n, installation)
         labeled_time = issue.get_label_added_date('Close?')
@@ -68,18 +73,19 @@ def process_issues(repository, installation):
             comment_ids = issue.find_comments('astropy-bot[bot]', filter_keep=is_close_epilogue)
             if len(comment_ids) == 0:
                 print(f'-> CLOSING issue {n}')
+                yield f'-> CLOSING issue {n}'
                 issue.set_labels(['closed-by-bot'])
                 issue.submit_comment(ISSUE_CLOSE_EPILOGUE)
                 issue.close()
             else:
-                print(f'-> Skipping issue {n} (already closed)')
+                yield f'-> Skipping issue {n} (already closed)'
         elif dt > current_app.stale_issue_warn_seconds:
             comment_ids = issue.find_comments('astropy-bot[bot]', filter_keep=is_close_warning)
             if len(comment_ids) == 0:
-                print(f'-> WARNING issue {n}')
+                yield f'-> WARNING issue {n}'
                 issue.submit_comment(ISSUE_CLOSE_WARNING.format(pasttime=naturaltime(dt),
                                                                 futuretime=naturaldelta(current_app.stale_issue_close_seconds - current_app.stale_issue_warn_seconds)))
             else:
-                print(f'-> Skipping issue {n} (already warned)')
+                yield f'-> Skipping issue {n} (already warned)'
         else:
-            print(f'-> OK issue {n}')
+            yield f'-> OK issue {n}'

--- a/changebot/blueprints/tests/test_stale_pull_requests.py
+++ b/changebot/blueprints/tests/test_stale_pull_requests.py
@@ -32,24 +32,27 @@ class TestHook:
     def test_valid(self):
         data = {'repository': 'test-repo', 'cron_token': '12345', 'installation': '123'}
         with patch('changebot.blueprints.stale_pull_requests.process_pull_requests') as p:
-            self.client.post('/close_stale_pull_requests', data=json.dumps(data),
-                             content_type='application/json')
+            response = self.client.post('/close_stale_pull_requests', data=json.dumps(data),
+                                        content_type='application/json')
+            assert response.data == b''
             assert p.call_count == 1
 
     @patch.object(app, 'cron_token', '12345')
     def test_invalid_cron(self):
         data = {'repository': 'test-repo', 'cron_token': '12344', 'installation': '123'}
         with patch('changebot.blueprints.stale_pull_requests.process_pull_requests') as p:
-            self.client.post('/close_stale_pull_requests', data=json.dumps(data),
-                             content_type='application/json')
+            response = self.client.post('/close_stale_pull_requests', data=json.dumps(data),
+                                        content_type='application/json')
+            assert response.data == b'Incorrect cron_token'
             assert p.call_count == 0
 
     @patch.object(app, 'cron_token', '12345')
     def test_missing_keyword(self):
         data = {'cron_token': '12344', 'installation': '123'}
         with patch('changebot.blueprints.stale_pull_requests.process_pull_requests') as p:
-            self.client.post('/close_stale_pull_requests', data=json.dumps(data),
-                             content_type='application/json')
+            response = self.client.post('/close_stale_pull_requests', data=json.dumps(data),
+                                        content_type='application/json')
+            assert response.data == b'Payload mising repository'
             assert p.call_count == 0
 
 
@@ -98,7 +101,8 @@ class TestProcessIssues:
         self.labels.return_value = ['io.fits', 'Bug']
 
         with app.app_context():
-            process_pull_requests('repo', 'installation')
+            # The list() call is to forge the generator to run fully
+            list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 0
         assert self.close.call_count == 0
@@ -113,7 +117,8 @@ class TestProcessIssues:
         self.find_comments.return_value = []
 
         with app.app_context():
-            process_pull_requests('repo', 'installation')
+            # The list() call is to forge the generator to run fully
+            list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 1
         expected = PULL_REQUESTS_CLOSE_EPILOGUE
@@ -131,7 +136,8 @@ class TestProcessIssues:
         self.find_comments.return_value = []
 
         with app.app_context():
-            process_pull_requests('repo', 'installation')
+            # The list() call is to forge the generator to run fully
+            list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 0
         assert self.close.call_count == 0
@@ -148,7 +154,8 @@ class TestProcessIssues:
 
         with app.app_context():
             with patch.object(app, 'stale_pull_requests_close', False):
-                process_pull_requests('repo', 'installation')
+                # The list() call is to forge the generator to run fully
+                list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 1
         expected = PULL_REQUESTS_CLOSE_WARNING.format(pasttime='4 minutes', futuretime='20 seconds')
@@ -166,7 +173,8 @@ class TestProcessIssues:
 
         with app.app_context():
             with patch.object(app, 'stale_pull_requests_close', False):
-                process_pull_requests('repo', 'installation')
+                # The list() call is to forge the generator to run fully
+                list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 1
         expected = PULL_REQUESTS_CLOSE_WARNING.format(pasttime='4 minutes', futuretime='20 seconds')
@@ -183,7 +191,8 @@ class TestProcessIssues:
         self.find_comments.return_value = ['1']
 
         with app.app_context():
-            process_pull_requests('repo', 'installation')
+            # The list() call is to forge the generator to run fully
+            list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 0
         assert self.close.call_count == 0
@@ -198,7 +207,8 @@ class TestProcessIssues:
         self.find_comments.return_value = []
 
         with app.app_context():
-            process_pull_requests('repo', 'installation')
+            # The list() call is to forge the generator to run fully
+            list(process_pull_requests('repo', 'installation'))
 
         assert self.submit_comment.call_count == 1
         expected = PULL_REQUESTS_CLOSE_WARNING.format(pasttime='3 minutes', futuretime='20 seconds')
@@ -214,7 +224,8 @@ class TestProcessIssues:
         self.find_comments.return_value = []
 
         with app.app_context():
-            process_pull_requests('repo', 'installation')
+            # The list() call is to forge the generator to run fully
+            list(process_pull_requests('repo', 'installation'))
 
         assert self.find_comments.call_count == 0
         assert self.submit_comment.call_count == 0


### PR DESCRIPTION
As described in https://librenepal.com/article/flask-and-heroku-timeout/, this should prevent timeouts as well as return the status of the checks to Travis