### PR TITLE
adding functionality to set labels

### DIFF
--- a/changebot/blueprints/stale_issues.py
+++ b/changebot/blueprints/stale_issues.py
@@ -68,6 +68,7 @@ def process_issues(repository, installation):
             comment_ids = issue.find_comments('astropy-bot[bot]', filter_keep=is_close_epilogue)
             if len(comment_ids) == 0:
                 print(f'-> CLOSING issue {n}')
+                issue.set_labels(['closed-by-bot'])
                 issue.submit_comment(ISSUE_CLOSE_EPILOGUE)
                 issue.close()
             else:

--- a/changebot/blueprints/tests/test_stale_issues.py
+++ b/changebot/blueprints/tests/test_stale_issues.py
@@ -65,12 +65,14 @@ class TestProcessIssues:
         self.patch_close = patch.object(IssueHandler, 'close')
         self.patch_get_label_added_date = patch.object(IssueHandler, 'get_label_added_date')
         self.patch_find_comments = patch.object(IssueHandler, 'find_comments')
+        self.patch_set_labels = patch.object(IssueHandler, 'set_labels')
 
         self.get_issues = self.patch_get_issues.start()
         self.submit_comment = self.patch_submit_comment.start()
         self.close = self.patch_close.start()
         self.get_label_added_date = self.patch_get_label_added_date.start()
         self.find_comments = self.patch_find_comments.start()
+        self.set_labels = self.patch_set_labels.start()
 
     def teardown_method(self, method):
 
@@ -79,6 +81,7 @@ class TestProcessIssues:
         self.patch_close.stop()
         self.patch_get_label_added_date.stop()
         self.patch_find_comments.stop()
+        self.patch_set_labels.stop()
 
     def test_close_comment_exists(self):
 
@@ -98,6 +101,7 @@ class TestProcessIssues:
 
         assert self.submit_comment.call_count == 0
         assert self.close.call_count == 0
+        assert self.set_labels.call_count == 0
 
     def test_close(self):
 
@@ -115,6 +119,7 @@ class TestProcessIssues:
         expected = ISSUE_CLOSE_EPILOGUE
         self.submit_comment.assert_called_with(expected)
         assert self.close.call_count == 1
+        assert self.set_labels.call_count == 1
 
     def test_close_disabled(self):
 
@@ -134,6 +139,7 @@ class TestProcessIssues:
         expected = ISSUE_CLOSE_WARNING.format(pasttime='9 hours ago', futuretime='5 hours')
         self.submit_comment.assert_called_with(expected)
         assert self.close.call_count == 0
+        assert self.set_labels.call_count == 0
 
     def test_warn_comment_exists(self):
 
@@ -149,6 +155,7 @@ class TestProcessIssues:
 
         assert self.submit_comment.call_count == 0
         assert self.close.call_count == 0
+        assert self.set_labels.call_count == 0
 
     def test_warn(self):
 
@@ -166,6 +173,7 @@ class TestProcessIssues:
         expected = ISSUE_CLOSE_WARNING.format(pasttime='9 hours ago', futuretime='5 hours')
         self.submit_comment.assert_called_with(expected)
         assert self.close.call_count == 0
+        assert self.set_labels.call_count == 0
 
     def test_keep_open(self):
 
@@ -181,3 +189,4 @@ class TestProcessIssues:
         assert self.find_comments.call_count == 0
         assert self.submit_comment.call_count == 0
         assert self.close.call_count == 0
+        assert self.set_labels.call_count == 0

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -317,6 +317,34 @@ class IssueHandler(object):
         assert response.ok, response.content
         return [label['name'] for label in response.json()]
 
+    def get_all_labels(self):
+        """Get all label options for this repo"""
+        url = f'{HOST}/repos/{self.repo}/labels'
+        response = requests.post(url, headers=self._headers)
+        assert response.ok, response.content
+        return [label['name'] for label in response.json()]
+
+    def set_labels(self, labels):
+        """Set label(s) to issue"""
+
+        if not isinstance(labels, list):
+            labels = [labels]
+
+        # If label already set, do nothing
+        missing_labels = set(labels).difference(self.labels)
+        if len(missing_labels) == 0:
+            return
+
+        # If label does not already exist in the repo, fail (or create it?)
+        missing_labels = missing_labels.difference(self.get_all_labels())
+        if len(missing_labels) == 0:
+            print(f'-> WARNING: Label does not exist: {missing_labels}')
+            return
+
+        # Set label(s) for issue
+        response = requests.post(self._url_labels, headers=self._headers, json=list(missing_labels))
+        assert response.ok, response.content
+
     def close(self):
         url = f'{HOST}/repos/{self.repo}/issues/{self.number}'
         parameters = {'state': 'closed'}

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -186,6 +186,13 @@ class RepoHandler(object):
             issue_list = [d['number'] for d in result]
         return issue_list
 
+    def get_all_labels(self):
+        """Get all label options for this repo"""
+        url = f'{HOST}/repos/{self.repo}/labels'
+        response = requests.get(url, headers=self._headers)
+        assert response.ok, response.content
+        return [label['name'] for label in response.json()]
+
 
 class IssueHandler(object):
 
@@ -313,14 +320,8 @@ class IssueHandler(object):
 
     @property
     def labels(self):
+        """Get labels for this issue"""
         response = requests.get(self._url_labels, headers=self._headers)
-        assert response.ok, response.content
-        return [label['name'] for label in response.json()]
-
-    def get_all_labels(self):
-        """Get all label options for this repo"""
-        url = f'{HOST}/repos/{self.repo}/labels'
-        response = requests.get(url, headers=self._headers)
         assert response.ok, response.content
         return [label['name'] for label in response.json()]
 
@@ -336,7 +337,7 @@ class IssueHandler(object):
             return
 
         # If label does not already exist in the repo, fail (or create it?)
-        missing_labels = missing_labels.difference(self.get_all_labels())
+        missing_labels = missing_labels.difference(self.repo.get_all_labels())
         if len(missing_labels) == 0:
             print(f'-> WARNING: Label does not exist: {missing_labels}')
             return

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -320,7 +320,7 @@ class IssueHandler(object):
     def get_all_labels(self):
         """Get all label options for this repo"""
         url = f'{HOST}/repos/{self.repo}/labels'
-        response = requests.post(url, headers=self._headers)
+        response = requests.get(url, headers=self._headers)
         assert response.ok, response.content
         return [label['name'] for label in response.json()]
 

--- a/changebot/github/tests/test_github_api.py
+++ b/changebot/github/tests/test_github_api.py
@@ -111,6 +111,30 @@ class TestIssueHandler:
             mock_json.return_value = {'state': state}
             assert self.issue.is_closed is answer
 
+    def test_missing_labels(self):
+        with patch('changebot.github.github_api.IssueHandler.labels', new_callable=PropertyMock) as mock_issue_labels:  # noqa
+            mock_issue_labels.return_value = ['io.fits']
+            with patch('changebot.github.github_api.RepoHandler.get_all_labels') as mock_repo_labels:  # noqa
+                mock_repo_labels.return_value = ['io.fits', 'closed-by-bot']
+
+                # closed-by-bot label will be added to issue in POST
+                missing_labels = self.issue._get_missing_labels('closed-by-bot')
+                assert missing_labels == ['closed-by-bot']
+
+                # Desired labels do not exist in repo
+                missing_labels = self.issue._get_missing_labels(
+                    ['dummy', 'foo'])
+                assert missing_labels is None
+
+                # Desired label already set on issue
+                missing_labels = self.issue._get_missing_labels(['io.fits'])
+                assert missing_labels is None
+
+                # A mix
+                missing_labels = self.issue._get_missing_labels(
+                    ['io.fits', 'closed-by-bot', 'foo'])
+                assert missing_labels == ['closed-by-bot']
+
 
 class TestPullRequestHandler:
     def setup_class(self):

--- a/changebot/github/tests/test_github_api.py
+++ b/changebot/github/tests/test_github_api.py
@@ -30,6 +30,16 @@ class TestRepoHandler:
         assert self.repo.get_issues('open', 'Close?',
                                     exclude_pr=False) == [42, 55]
 
+    @patch('requests.get')
+    def test_get_all_labels(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {'name': 'io.fits'},
+            {'name': 'Documentation'}]
+        mock_get.return_value = mock_response
+
+        assert self.repo.get_all_labels() == ['io.fits', 'Documentation']
+
     def test_urls(self):
         assert self.repo._url_contents == 'https://api.github.com/repos/fakerepo/doesnotexist/contents/'
         assert self.repo._url_pull_requests == 'https://api.github.com/repos/fakerepo/doesnotexist/pulls'


### PR DESCRIPTION
Some additional methods to IssueHandler to allow for labels to be set (#54). Also added a line in stale issues to add the 'closed-by-bot' label on issues that are auto-closed.

Also relevant to issues #65 and #66 

Tests are still needed for the new method.