### PR TITLE
Enable manual skipping of changelog checks via label

### DIFF
--- a/changebot/blueprints/changelog_helpers.py
+++ b/changebot/blueprints/changelog_helpers.py
@@ -72,6 +72,11 @@ def review_changelog(pull_request, changelog, is_modified, milestone, labels):
 
     issues = []
 
+    # Changelog checks manually disabled for this pull request.
+    # This is originally for post-release insertion of new changelog sections.
+    if 'skip-changelog-checks' in labels:
+        return issues
+
     if not milestone:
         issues.append("The milestone has not been set (this can only be set by a maintainer)")
 

--- a/changebot/blueprints/tests/test_changelog_helpers.py
+++ b/changebot/blueprints/tests/test_changelog_helpers.py
@@ -73,7 +73,9 @@ foo.frob.blurg
     assert len(issues) == 0
 
 
-@pytest.mark.parametrize('label', ['no-changelog-entry-needed', 'Affects-dev'])
+@pytest.mark.parametrize('label', ['no-changelog-entry-needed',
+                                   'Affects-dev',
+                                   'skip-changelog-checks'])
 def test_review_missing_with_tag(label):
     content = """
 1.1.0 (unreleased)

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 
 import dateutil.parser
 import toml
-from flask import current_app
 
 from changebot.github.github_auth import github_request_headers
 
@@ -133,7 +132,7 @@ class RepoHandler(object):
         try:
             file_content = self.get_file_contents(path_to_file)
             cfg = toml.loads(file_content)
-            cfg = cfg['tool'][current_app.bot_username]
+            cfg = cfg['tool']['astropy-bot']
         except Exception as e:
             if warn_on_failure:
                 warnings.warn(str(e))

--- a/changebot/github/tests/test_github_api.py
+++ b/changebot/github/tests/test_github_api.py
@@ -50,7 +50,6 @@ class TestRepoHandler:
 # NOTE: Might hit API limit?
 class TestRealRepoHandler:
     def setup_class(self):
-        # TODO: Use astropy/astropy-bot when #42 is merged.
         self.repo = RepoHandler('astropy/astropy-bot')
 
     def test_get_config(self):
@@ -66,7 +65,7 @@ class TestRealRepoHandler:
         other_warns = []
         for ww in w:
             s = str(ww.message)
-            if 'API limit' in s:
+            if 'API rate limit' in s:
                 hit_api_limit = True
             else:
                 other_warns.append(s)


### PR DESCRIPTION
Fix #64 as @astrofrog suggested. Hopefully this will get rid of "false positive" in PRs like astropy/astropy#7525 when a maintainer adds new change log sections after a release.

c/c @bsipocz 