### PR TITLE
Improve stale pull request logic

### DIFF
--- a/changebot/blueprints/stale_pull_requests.py
+++ b/changebot/blueprints/stale_pull_requests.py
@@ -94,17 +94,15 @@ def process_pull_requests(repository, installation):
         # didn't exist since it's no longer relevant.
         warning_time = pr.last_comment_date('astropy-bot[bot]', filter_keep=is_close_warning)
         if warning_time is None or warning_time < commit_time:
-            has_warning = False
             time_since_last_warning = 0.
         else:
-            has_warning = True
             time_since_last_warning = now - warning_time
 
         # We only close pull requests if there has been a warning before, and
         # the time since the warning exceeds the threshold specified by
         # stale_pull_requests_close_seconds.
 
-        if has_warning and time_since_last_warning > current_app.stale_pull_requests_close_seconds:
+        if time_since_last_warning > current_app.stale_pull_requests_close_seconds:
             comment_ids = pr.find_comments('astropy-bot[bot]', filter_keep=is_close_epilogue)
             if not current_app.stale_pull_requests_close or not enable_autoclose:
                 print(f'-> Skipping pull request {n} (auto-close disabled)')


### PR DESCRIPTION
This changes the logic of the stale PR blueprint in the following way

* Closing is only ever done if a warning has been posted before, regardless of the time since the last commit.

* The ``stale_pull_requests_close_seconds`` now has a different meaning - it is the time since the last warning after which a pull request is closed (not since the latest commit). This ensures that even if the bot is late in warning, the closing always happens a fixed time after the warning.

* Warnings about closing that pre-date the latest commit are ignored. Fixes https://github.com/astropy/astropy-bot/issues/38

* Fixed some of the logic about missing labels. Fixes https://github.com/astropy/astropy-bot/issues/89

* If the keep open label is present, no warning is emitted (somehow the test seemed to suggest a warning would be emitted previously)
 
Once this is merged, I will update the Heroku config to modify the default value of ``stale_pull_requests_close_seconds``.