### PR TITLE
Introduce a delay when looking for previous comments from the bot

### DIFF
--- a/changebot/blueprints/pull_request_checker.py
+++ b/changebot/blueprints/pull_request_checker.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import time
 
 from flask import Blueprint, request
 
@@ -99,6 +100,11 @@ def process_changelog_consistency(repository, number, installation):
     # No-op if user so desires
     if not repo_handler.get_config_value('changelog_check', True):
         return "Repo owner does not want to check change log"
+
+    # Wait a little, to make sure that if we posted comments previously they
+    # have had time to appear. We need this because GitHub sometimes fires
+    # pull request events in quick succession.
+    time.sleep(2.)
 
     # Find previous comments by this app
     comment_ids = pr_handler.find_comments(


### PR DESCRIPTION
This is to avoid the many comments per pull request.

This is a bit of a shot in the dark, but I think what's likely happening is that GitHub fires multiple events (e.g. for the PR itself, then for each label/milestone which is set initially) and we process them faster than GitHub can post the first comment. So this just does something dumb which is to introduce a delay before we check for previous comments. It might work though? 🤞 