### PR TITLE
Make changelog check insensitive to 'v' prefix in milestone or changelog version

### DIFF
--- a/astropy_bot/changelog_checker.py
+++ b/astropy_bot/changelog_checker.py
@@ -39,20 +39,30 @@ def check_changelog_consistency(pr_handler, repo_handler):
 
     elif len(versions) == 1:
 
+        # Extract milestone and version
+        milestone = pr_handler.milestone
+        version = versions[0]
+
+        # Strip any 'v' prefix from these
+        if milestone is not None and milestone.startswith('v'):
+            milestone = milestone[1:]
+        if version.startswith('v'):
+            version = version[1:]
+
         if 'no-changelog-entry-needed' in pr_handler.labels:
             statuses['changelog'] = {'description': 'Changelog entry present but **no-changelog-entry-needed** label set',
                                      'state': 'failure'}
         elif 'Affects-dev' in pr_handler.labels:
             statuses['changelog'] = {'description': 'Changelog entry present but **Affects-dev** label set',
                                      'state': 'failure'}
-        elif pr_handler.milestone:
-            if pr_handler.milestone.startswith(versions[0]):
+        elif milestone:
+            if milestone.startswith(version):
                 statuses['changelog'] = {'description': 'Changelog entry consistent with milestone',
                                          'state': 'success'}
             else:
                 statuses['changelog'] = {'description': 'Changelog entry section ({0}) '
                                          'inconsistent with milestone ({1})'
-                                         .format(versions[0], pr_handler.milestone),
+                                         .format(version, milestone),
                                          'state': 'failure'}
         else:
             statuses['changelog'] = {'description': 'Cannot check for consistency of milestone since milestone is not set',

--- a/astropy_bot/tests/test_changelog_checker.py
+++ b/astropy_bot/tests/test_changelog_checker.py
@@ -152,6 +152,23 @@ class TestPullRequestChecker:
         assert statuses == {'changelog': {'description': 'Changelog entry consistent with milestone',
                                           'state': 'success'}}
 
+    def test_one_version_valid_withv(self, app):
+
+        # As above, but where milestone includes a 'v' prefix
+        changelog = ('1.0 (2018-10-22)\n'
+                     '----------------\n'
+                     '* change1 [#1234]\n')
+
+        self.files['CHANGES.rst'] = changelog
+        self.config['changelog_checker'] = {'filename': 'CHANGES.rst'}
+        self.pr_handler.milestone = 'v1.0'
+
+        with app.app_context():
+            statuses = check_changelog_consistency(self.pr_handler, self.repo_handler)
+
+        assert statuses == {'changelog': {'description': 'Changelog entry consistent with milestone',
+                                          'state': 'success'}}
+
     def test_no_version_no_changelog_entry_needed(self, app):
 
         # Test case where there is a changelog entry but the


### PR DESCRIPTION
Will fix issue reported by @pllim in https://github.com/astropy/astropy/pull/8167#issuecomment-441125534