### PR TITLE
Use repo_handler instead of pr_handler to get config in pull request branch

### DIFF
--- a/astropy_bot/changelog_checker.py
+++ b/astropy_bot/changelog_checker.py
@@ -13,7 +13,7 @@ def check_changelog_consistency(pr_handler, repo_handler):
     if 'skip-changelog-checks' in labels:
         return {}
 
-    cl_config = pr_handler.get_config_value("changelog_checker", {})
+    cl_config = repo_handler.get_config_value("changelog_checker", {})
     filename = cl_config.get("filename", 'CHANGES.rst')
 
     statuses = {}

--- a/astropy_bot/tests/test_changelog_checker.py
+++ b/astropy_bot/tests/test_changelog_checker.py
@@ -22,6 +22,7 @@ class TestPullRequestChecker:
 
         self.repo_handler = MagicMock()
         self.repo_handler.get_file_contents = self.get_file_contents
+        self.repo_handler.get_config_value = self.get_config_value
 
     def get_file_contents(self, filename, branch=None):
         if filename in self.files:


### PR DESCRIPTION
This is due to bug in PullRequestHandler (https://github.com/OpenAstronomy/baldrick/issues/41)