### PR TITLE
Add a new check for copyediting

### DIFF
--- a/astropy_bot/copyedit_checker.py
+++ b/astropy_bot/copyedit_checker.py
@@ -1,0 +1,32 @@
+from baldrick.plugins.github_pull_requests import pull_request_handler
+
+
+COPYEDITOR_GH_HANDLE = 'lglattly'
+
+
+@pull_request_handler
+def check_copyedit_docs(pr_handler, repo_handler):
+    statuses = {}
+
+    if 'docs' in pr_handler.labels:
+        if 'copyedited' in pr_handler.labels:
+            statuses['copyedit'] = {
+                'description': "This PR has been copyedited.",
+                'state': 'success'
+            }
+
+        else:
+            statuses['copyedit'] = {
+                'description': "This PR modifies the documentation and is "
+                               "waiting for copyediting. No action is needed "
+                               "from the contributor.",
+                'state': 'failure'
+            }
+
+    else:
+        return None
+
+    if COPYEDITOR_GH_HANDLE not in pr_handler.json['assignees']:
+        pr_handler.add_assignees(COPYEDITOR_GH_HANDLE)
+
+    return statuses

--- a/astropy_bot/copyedit_checker.py
+++ b/astropy_bot/copyedit_checker.py
@@ -1,6 +1,8 @@
 from baldrick.plugins.github_pull_requests import pull_request_handler
 
 
+# TODO: we need to note somewhere that if the copyeditor changes, this needs to
+# be updated!
 COPYEDITOR_GH_HANDLE = 'lglattly'
 
 

--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ import baldrick.plugins.github_milestones  # noqa
 
 # Load astropy-specific plugins
 import astropy_bot.changelog_checker  # noqa
+import astropy_bot.copyedit_checker  # noqa
 
 # Bind to PORT if defined, otherwise default to 5000.
 port = int(os.environ.get('PORT', 5000))


### PR DESCRIPTION
This fixes #104. 

This adds a new PR check that fails if the label "docs" is set unless the label "copyedited" has been added.

Note that this depends on functionality added to baldrick in OpenAstronomy/baldrick#76, and so shouldn't be merged until that PR is resolved and merged.