### PR TITLE
Autolabel pull requests by looking at what subpackage files are touched

### DIFF
--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -3,17 +3,56 @@ from baldrick.plugins.github_pull_requests import pull_request_handler
 
 
 def get_subpackage_labels(files, all_labels):
+    """Loop through all modified file paths and extract the path elements for
+    each of the files. Then see if any of these paths or subsets of the path
+    exist as labels in the repo. This ignores the root of the path, so that,
+    e.g., astropy/coordinates and docs/coordinates both get caught and matched
+    to a "coordinates" label. Because this also considers all cumulative subsets
+    of the path, the following all map to, e.g., a "coordinates" label:
+
+        astropy/coordinates/file.py
+        astropy/coordinates/tests/file.py
+        astropy/coordinates/stuff/tests/file.py
+        docs/coordinates/stuff/file.rst
+
+    Parameters
+    ----------
+    files : iterable
+        A list or iterable of full path names to files modified by a pull
+        request.
+    all_labels : iterable
+        A list or iterable of all labels defined for the repository.
+
+    Returns
+    -------
+    labels : set
+        A set containing all subpackage labels to be added to the pull request
+        that already exist in the input ``all_labels``.
+
+    """
     labels = set()
 
     for file_ in files:
+        # Each file_ is assumed to be a full path to a modified file within
+        # the repository. This then grabs the directory name of the file_,
+        # stripping off the filename itself:
         subdir = path.dirname(file_)
 
+        # If we are in a subdirectory:
         if subdir:
+            # Get the subdirectory root name (e.g., "packagename" or "docs"),
+            # and the rest of the path:
             root, *subpkg = subdir.split(sep)
 
             if subpkg:
+                # Consider all possible, cumulative path subsets:
                 for i in range(len(subpkg)):
+                    # Assume that the subpackage labels for sub-sub packages
+                    # contain dots
                     dot_name = '.'.join(subpkg[:i + 1])
+
+                    # Only add the label if it exists in the full likst of
+                    # repository labels
                     if dot_name in all_labels:
                         labels.add(dot_name)
 

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -13,7 +13,7 @@ def get_subpackage_labels(files, all_labels):
 
             if subpkg:
                 for i in range(len(subpkg)):
-                    dot_name = '.'.join(subpkg[:i+1])
+                    dot_name = '.'.join(subpkg[:i + 1])
                     if dot_name in all_labels:
                         labels.add(dot_name)
 

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -68,7 +68,7 @@ def autolabel(pr_handler, repo_handler):
     pr_labels = set(pr_handler.labels)
     new_labels = set()
 
-    if al_config.get('subpackages', False):
+    if al_config.get('subpackages', True):
         labels = get_subpackage_labels(files, all_labels)
         new_labels = new_labels.union(labels)
 

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -2,23 +2,40 @@ from os import path, sep
 from baldrick.plugins.github_pull_requests import pull_request_handler
 
 
-@pull_request_handler
-def autolabel_subpackages(pr_handler, repo_handler):
-    files = pr_handler.get_modified_files()
-    all_labels = repo_handler.get_all_labels()
-    existing_labels = set(pr_handler.labels)
+def get_subpackage_labels(files, all_labels):
+    labels = set()
 
-    for file in files:
-        subdir = path.dirname(file)
+    for file_ in files:
+        subdir = path.dirname(file_)
 
         if subdir:
             root, *subpkg = subdir.split(sep)
 
             if subpkg:
-                dot_name = '.'.join(subpkg)
-                if dot_name in all_labels and dot_name not in existing_labels:
-                    existing_labels.add(dot_name)
+                for i in range(len(subpkg)):
+                    dot_name = '.'.join(subpkg[:i+1])
+                    if dot_name in all_labels:
+                        labels.add(dot_name)
 
-    pr_handler.set_labels(existing_labels)
+    return labels
+
+
+@pull_request_handler
+def autolabel(pr_handler, repo_handler):
+
+    al_config = repo_handler.get_config_value("autolabel", {})
+    files = pr_handler.get_modified_files()
+    all_labels = repo_handler.get_all_labels()
+    pr_labels = set(pr_handler.labels)
+    new_labels = set()
+
+    if al_config.get('subpackages', False):
+        labels = get_subpackage_labels(files, all_labels)
+        new_labels = new_labels.union(labels)
+
+    # TODO: add other auto-labeling logic here
+
+    if new_labels:
+        pr_handler.set_labels(pr_labels.union(new_labels))
 
     return None

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -51,7 +51,7 @@ def get_subpackage_labels(files, all_labels):
                     # contain dots
                     dot_name = '.'.join(subpkg[:i + 1])
 
-                    # Only add the label if it exists in the full likst of
+                    # Only add the label if it exists in the full list of
                     # repository labels
                     if dot_name in all_labels:
                         labels.add(dot_name)

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -75,6 +75,6 @@ def autolabel(pr_handler, repo_handler):
     # TODO: add other auto-labeling logic here
 
     if new_labels:
-        pr_handler.set_labels(pr_labels.union(new_labels))
+        pr_handler.set_labels(list(pr_labels.union(new_labels)))
 
     return None

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -59,7 +59,7 @@ def get_subpackage_labels(files, all_labels):
     return labels
 
 
-@pull_request_handler
+@pull_request_handler(actions=['opened'])
 def autolabel(pr_handler, repo_handler):
 
     al_config = repo_handler.get_config_value("autolabel", {})

--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -1,0 +1,24 @@
+from os import path, sep
+from baldrick.plugins.github_pull_requests import pull_request_handler
+
+
+@pull_request_handler
+def autolabel_subpackages(pr_handler, repo_handler):
+    files = pr_handler.get_modified_files()
+    all_labels = repo_handler.get_all_labels()
+    existing_labels = set(pr_handler.labels)
+
+    for file in files:
+        subdir = path.dirname(file)
+
+        if subdir:
+            root, *subpkg = subdir.split(sep)
+
+            if subpkg:
+                dot_name = '.'.join(subpkg)
+                if dot_name in all_labels and dot_name not in existing_labels:
+                    existing_labels.add(dot_name)
+
+    pr_handler.set_labels(existing_labels)
+
+    return None

--- a/astropy_bot/tests/test_autolabel.py
+++ b/astropy_bot/tests/test_autolabel.py
@@ -1,0 +1,63 @@
+# For these tests, we patch the repo and pull request handler directly rather
+# than the requests to the server, as we assume the repo and pull request
+# handlers are tested inside baldrick.
+
+from unittest.mock import MagicMock
+
+from astropy_bot.autolabel import autolabel_subpackages
+
+
+class TestAutolabel:
+
+    def setup_method(self, method):
+
+        self.files = [
+            {'filename': 'CHANGES.rst'},
+            {'filename': 'astropy/io/fits/convenience.py'},
+            {'filename': 'astropy/io/fits/fitstime.py'},
+            {'filename': 'astropy/io/fits/tests/test_fitstime.py'},
+            {'filename': 'astropy/coordinates/baseframe.py'},
+            {'filename': 'astropy/visualization/wcsaxes/coordinate_helpers.py'}
+        ]
+        self.all_labels = ['analytic_functions', 'config', 'constants',
+                           'convolution', 'coordinates', 'cosmology',
+                           'io.ascii', 'io.fits', 'io.misc', 'io.misc.asdf',
+                           'io.registry', 'io.votable', 'modeling', 'nddata',
+                           'samp', 'stats', 'table', 'time', 'timeseries',
+                           'uncertainty', 'units', 'utils', 'visualization',
+                           'visualization.wcsaxes', 'vo', 'vo.conesearch',
+                           'wcs', 'wcs.wcsapi']
+
+        self.pr_handler = MagicMock()
+        self.pr_handler.number = 1234
+        self.pr_handler.labels = ['Docs']
+        self.pr_handler.milestone = None
+        self.pr_handler.set_labels = self.set_labels
+
+        self.repo_handler = MagicMock()
+        self.repo_handler.get_modified_files = self.get_modified_files
+        self.repo_handler.get_all_labels = self.get_all_labels
+
+    # Patched methods:
+    def get_modified_files(self):
+        return self.files
+
+    def get_all_labels(self):
+        return self.all_labels
+
+    def set_labels(self, labels):
+        self.labels = labels
+
+    # Tests:
+    def test_autolabel_subpackages(self, app):
+        with app.app_context():
+            autolabel_subpackages(self.pr_handler, self.repo_handler)
+
+        # make sure 'Docs' stays in there:
+        assert 'Docs' in self.pr_handler.labels
+
+        # now check that all the subpackage labels are added:
+        assert 'io.fits' in self.pr_handler.labels
+        assert 'coordinates' in self.pr_handler.labels
+        assert 'visualization.wcsaxes' in self.pr_handler.labels
+        

--- a/astropy_bot/tests/test_autolabel.py
+++ b/astropy_bot/tests/test_autolabel.py
@@ -60,4 +60,3 @@ class TestAutolabel:
         assert 'io.fits' in self.pr_handler.labels
         assert 'coordinates' in self.pr_handler.labels
         assert 'visualization.wcsaxes' in self.pr_handler.labels
-        

--- a/astropy_bot/tests/test_autolabel.py
+++ b/astropy_bot/tests/test_autolabel.py
@@ -11,14 +11,12 @@ class TestAutolabel:
 
     def setup_method(self, method):
 
-        self.files = [
-            {'filename': 'CHANGES.rst'},
-            {'filename': 'astropy/io/fits/convenience.py'},
-            {'filename': 'astropy/io/fits/fitstime.py'},
-            {'filename': 'astropy/io/fits/tests/test_fitstime.py'},
-            {'filename': 'astropy/coordinates/baseframe.py'},
-            {'filename': 'astropy/visualization/wcsaxes/coordinate_helpers.py'}
-        ]
+        self.files = ['CHANGES.rst', 'astropy/io/fits/convenience.py',
+                      'astropy/io/fits/fitstime.py',
+                      'astropy/io/fits/tests/test_fitstime.py',
+                      'astropy/coordinates/baseframe.py',
+                      'astropy/visualization/wcsaxes/coordinate_helpers.py']
+
         self.all_labels = ['analytic_functions', 'config', 'constants',
                            'convolution', 'coordinates', 'cosmology',
                            'io.ascii', 'io.fits', 'io.misc', 'io.misc.asdf',
@@ -33,9 +31,9 @@ class TestAutolabel:
         self.pr_handler.labels = ['Docs']
         self.pr_handler.milestone = None
         self.pr_handler.set_labels = self.set_labels
+        self.pr_handler.get_modified_files = self.get_modified_files
 
         self.repo_handler = MagicMock()
-        self.repo_handler.get_modified_files = self.get_modified_files
         self.repo_handler.get_all_labels = self.get_all_labels
 
     # Patched methods:
@@ -57,6 +55,6 @@ class TestAutolabel:
         assert 'Docs' in self.pr_handler.labels
 
         # now check that all the subpackage labels are added:
-        assert 'io.fits' in self.pr_handler.labels
-        assert 'coordinates' in self.pr_handler.labels
-        assert 'visualization.wcsaxes' in self.pr_handler.labels
+        assert 'io.fits' in self.labels
+        assert 'coordinates' in self.labels
+        assert 'visualization.wcsaxes' in self.labels

--- a/astropy_bot/tests/test_autolabel.py
+++ b/astropy_bot/tests/test_autolabel.py
@@ -4,27 +4,21 @@
 
 from unittest.mock import MagicMock
 
-from astropy_bot.autolabel import autolabel_subpackages
+from astropy_bot.autolabel import autolabel
 
 
-class TestAutolabel:
+class AutolabelBase:
+
+    all_labels = ['analytic_functions', 'config', 'constants',
+                  'convolution', 'coordinates', 'cosmology',
+                  'io.ascii', 'io.fits', 'io.misc', 'io.misc.asdf',
+                  'io.registry', 'io.votable', 'modeling', 'nddata',
+                  'samp', 'stats', 'table', 'time', 'timeseries',
+                  'uncertainty', 'units', 'utils', 'visualization',
+                  'visualization.wcsaxes', 'vo', 'vo.conesearch',
+                  'wcs', 'wcs.wcsapi']
 
     def setup_method(self, method):
-
-        self.files = ['CHANGES.rst', 'astropy/io/fits/convenience.py',
-                      'astropy/io/fits/fitstime.py',
-                      'astropy/io/fits/tests/test_fitstime.py',
-                      'astropy/coordinates/baseframe.py',
-                      'astropy/visualization/wcsaxes/coordinate_helpers.py']
-
-        self.all_labels = ['analytic_functions', 'config', 'constants',
-                           'convolution', 'coordinates', 'cosmology',
-                           'io.ascii', 'io.fits', 'io.misc', 'io.misc.asdf',
-                           'io.registry', 'io.votable', 'modeling', 'nddata',
-                           'samp', 'stats', 'table', 'time', 'timeseries',
-                           'uncertainty', 'units', 'utils', 'visualization',
-                           'visualization.wcsaxes', 'vo', 'vo.conesearch',
-                           'wcs', 'wcs.wcsapi']
 
         self.pr_handler = MagicMock()
         self.pr_handler.number = 1234
@@ -46,10 +40,17 @@ class TestAutolabel:
     def set_labels(self, labels):
         self.labels = labels
 
-    # Tests:
+
+class TestAutolabel1(AutolabelBase):
+    files = ['CHANGES.rst', 'astropy/io/fits/convenience.py',
+             'astropy/io/fits/fitstime.py',
+             'astropy/io/fits/tests/test_fitstime.py',
+             'astropy/coordinates/baseframe.py',
+             'astropy/visualization/wcsaxes/coordinate_helpers.py']
+
     def test_autolabel_subpackages(self, app):
         with app.app_context():
-            autolabel_subpackages(self.pr_handler, self.repo_handler)
+            autolabel(self.pr_handler, self.repo_handler)
 
         # make sure 'Docs' stays in there:
         assert 'Docs' in self.pr_handler.labels
@@ -58,3 +59,19 @@ class TestAutolabel:
         assert 'io.fits' in self.labels
         assert 'coordinates' in self.labels
         assert 'visualization.wcsaxes' in self.labels
+
+
+class TestAutolabel2(AutolabelBase):
+    files = ['astropy/io/fits/tests/test_thing.py',
+             'docs/units/thing.rst']
+
+    def test_autolabel_subpackages(self, app):
+        with app.app_context():
+            autolabel(self.pr_handler, self.repo_handler)
+
+        # make sure 'Docs' stays in there:
+        assert 'Docs' in self.pr_handler.labels
+
+        # now check that all the subpackage labels are added:
+        assert 'io.fits' in self.labels
+        assert 'units' in self.labels

--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ import baldrick.plugins.github_milestones  # noqa
 
 # Load astropy-specific plugins
 import astropy_bot.changelog_checker  # noqa
+import astropy_bot.autolabel  # noqa
 
 # Bind to PORT if defined, otherwise default to 5000.
 port = int(os.environ.get('PORT', 5000))


### PR DESCRIPTION
This is my attempt to fix #65 

This looks at files modified in a given pull request, pulls out all subpackages that are touched, and adds labels for all subpackages if the label exists in the repo.

We might want to add a way to disable the auto-labeling? As is, it is very aggressive!