### PR TITLE
Enable base branch check for PR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.astropy-bot]
 
-[ tool.astropy-bot.milestones ]
+[tool.astropy-bot.milestones]
 
 enabled = true
 
@@ -14,3 +14,8 @@ skip_fails = true
 # We keep the following for now because it is used to identify
 # and remove/edit old comments the bot posted in the past.
 pull_request_substring = "issues related to the changelog"
+
+[tool.astropy-bot.basebranch_checker]
+
+enabled = true
+basebranch = master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,4 @@ pull_request_substring = "issues related to the changelog"
 [tool.astropy-bot.basebranch_checker]
 
 enabled = true
-basebranch = master
+basebranch = "master"


### PR DESCRIPTION
This is a follow up of OpenAstronomy/baldrick#92 . Hopefully this would prevent PRs from being opened accidentally against something other than `master`, especially when they click "edit on GitHub" on RTD doc.

Please double check the syntax.