### PR TITLE
Fix skip autolabel, enable disabling changelog check

### DIFF
--- a/astropy_bot/autolabel.py
+++ b/astropy_bot/autolabel.py
@@ -74,6 +74,7 @@ def autolabel(pr_handler, repo_handler):
     al_config = upstream_repo.get_config_value("autolabel", {})
     if not al_config.get("enabled", True):
         print("Skipping PR autolabel, disabled in config.")
+        return
 
     files = pr_handler.get_modified_files()
 

--- a/astropy_bot/changelog_checker.py
+++ b/astropy_bot/changelog_checker.py
@@ -6,6 +6,11 @@ from baldrick.plugins.github_pull_requests import pull_request_handler
 @pull_request_handler
 def check_changelog_consistency(pr_handler, repo_handler):
 
+    cl_config = repo_handler.get_config_value("changelog_checker", {})
+    if not cl_config.get("enabled", True):
+        print("Skipping PR changelog check, disabled in config.")
+        return
+
     labels = pr_handler.labels
 
     # Changelog checks manually disabled for this pull request.
@@ -13,7 +18,6 @@ def check_changelog_consistency(pr_handler, repo_handler):
     if 'skip-changelog-checks' in labels:
         return {}
 
-    cl_config = repo_handler.get_config_value("changelog_checker", {})
     filename = cl_config.get("filename", 'CHANGES.rst')
 
     statuses = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@
 
 enabled = true
 
+[tool.astropy-bot.changelog_checker]
+
+enabled = true
+
 [tool.astropy-bot.milestones]
 
 enabled = true


### PR DESCRIPTION
BUG: Fix skip autolabel. Forgot to `return` in #123 😱 

ENH: Enable disabling changelog check.