### PR TITLE
MNT: Replace master with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/astropy/astropy-bot/workflows/CI/badge.svg)](https://github.com/astropy/astropy-bot/actions)
-[![Coverage Status](https://codecov.io/gh/astropy/astropy-bot/branch/master/graph/badge.svg)](https://codecov.io/gh/astropy/astropy-bot)
+[![Coverage Status](https://codecov.io/gh/astropy/astropy-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/astropy/astropy-bot)
 
 ### About
 


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.